### PR TITLE
페이지내이션과 검색어 충돌 오류 해결

### DIFF
--- a/client/src/pages/Main.jsx
+++ b/client/src/pages/Main.jsx
@@ -104,8 +104,10 @@ export default function Main() {
   useEffect(() => {
     if (search) {
       setFilteredPosts(posts.filter((post) => post.title.includes(search)));
+      setPage(1);
     } else {
       setFilteredPosts(posts);
+      setPage(1);
     }
   }, [search, posts, pageNum]);
 
@@ -128,7 +130,9 @@ export default function Main() {
             ></input>
             <FontAwesomeIcon
               icon={faMagnifyingGlass}
-              onClick={() => setSearch(text)}
+              onClick={() => {
+                setSearch(text);
+              }}
             ></FontAwesomeIcon>
           </Search>
           <select


### PR DESCRIPTION
검색어를 입력하고 나온 결과가 여러 페이지인 경우
1페이지가 아닌 다른 페이지에서 또 다른 검색어를 입력했을 때
뒤에 입력한 검색어로 나온 결과가 1페이지의 결과만 있다면 나타나지 않는 현상이 있었습니다.
해결방법
- 다시 검색어를 통한 포스트 데이터를 가져올 때 페이지값 state인 page도 초기화 해주었다.